### PR TITLE
Add lifecycle-viewmodel to app build.gradle

### DIFF
--- a/lite/examples/object_detection/android/app/build.gradle
+++ b/lite/examples/object_detection/android/app/build.gradle
@@ -120,4 +120,9 @@ dependencies {
     // Import the GPU delegate plugin Library for GPU inference
     implementation 'org.tensorflow:tensorflow-lite-gpu-delegate-plugin:0.4.0'
     implementation 'org.tensorflow:tensorflow-lite-gpu:2.9.0'
+
+    //Viewmodel libraries
+    def lifecycle_version = "2.4.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
 }


### PR DESCRIPTION
Fixes a number of issues that arise when trying to run on Android Studio Iguana | 2023.2.1:

![312059699-e0053197-5e56-4baa-b223-58cde75bd480](https://github.com/UnreachableCode/examples/assets/1167553/c68b8d1a-100b-4b11-845f-765a579983f6)
